### PR TITLE
Flask support for Appfog

### DIFF
--- a/profiles/appfog.json
+++ b/profiles/appfog.json
@@ -82,6 +82,10 @@
       ]
     },
     {
+      "name": "flask",
+      "runtime": "python"
+    },
+    {
       "name": "rails",
       "runtime": "ruby",
       "versions": [


### PR DESCRIPTION
AppFog has, according to its documentation, support for Flask in addition to Django.

Source: https://docs.appfog.com/languages/python/flask
