### PR TITLE
Update Apprenda 6

### DIFF
--- a/profiles/apprenda.json
+++ b/profiles/apprenda.json
@@ -1,17 +1,20 @@
 {
   "name": "Apprenda",
-  "revision": "2015-05-18T18:00:44+02:00",
+  "revision": "2015-05-22",
   "vendor_verified": "2015-05-18",
   "url": "http://apprenda.com/",
   "status": "production",
-  "status_since": "2015-05-18",
+  "status_since": "2008-12-02",
   "type": "SaaS-centric",
   "hosting": {
-    "public": true,
+    "public": false,
     "private": true
   },
   "pricing": [
-    { "model" : "fixed", "period": "annually" }
+    {
+      "model": "fixed",
+      "period": "annually"
+    }
   ],
   "scaling": {
     "vertical": true,
@@ -22,45 +25,19 @@
     {
       "language": "dotnet",
       "versions": [
-        "3.5", "4.0", "4.5", "4.5.1"
+        "3.5",
+        "4.0",
+        "4.5.*"
       ]
     },
     {
       "language": "java",
       "versions": [
-        "1.6", "1.7", "1.8"
+        "1.6",
+        "1.7",
+        "1.8"
       ]
-    },
-    {
-      "language": "python",
-      "versions": [
-        "2.7", "3.4"
-      ]
-    },
-    {
-      "language": "ruby",
-      "versions": [
-        "2.2.2"
-      ]
-    }, 
-    {
-      "language": "node",
-      "versions": [
-        "0.12.3"
-      ]
-    },
-    {
-      "language": "go",
-      "versions": [
-        "1.4"
-      ]
-    },
-    {
-      "language": "php",
-      "versions": [
-        "5.4", "5.5", "5.6"
-      ]
-    }, 
+    }
   ],
   "middleware": [
     {
@@ -74,7 +51,8 @@
       "name": "tomcat",
       "runtime": "java",
       "versions": [
-        "6", "7"
+        "6",
+        "7"
       ]
     },
     {
@@ -90,23 +68,24 @@
       {
         "name": "SQL Server",
         "versions": [
-          "2008R2", "2012"
+          "2008R2",
+          "2012"
         ],
-        "type": "Database"
+        "type": "datastore"
       },
       {
         "name": "Oracle",
         "versions": [
           "11g"
-          ],
-          "type": "Database"
+        ],
+        "type": "datastore"
       },
       {
         "name": "Docker",
-        "versions":[
+        "versions": [
           "1.6"
-          ],
-        "type": "Container"
+        ],
+        "type": "other"
       }
     ],
     "addon": [
@@ -217,19 +196,8 @@
       }
     ]
   },
-  "extensible": true,
+  "extensible": false,
   "infrastructures": [
-    {
-      "continent": "AF, AS, EU, NA, OC, SA",
-      "provider": "AWS"
-    },
-    {
-      "continent": "AF, AS, EU, NA, OC, SA",
-      "provider": "Microsoft Azure"
-    },
-    {
-      "continent": "AF, AS, EU, NA, OC, SA",
-      "provider": "OpenStack"
-    }
+
   ]
 }


### PR DESCRIPTION
@dutronlabs Following changes were made to PR #127.
Please correct me if I'm wrong with anything.

1. Removed additional languages that are related to Docker deployments. This would potentially allow any language to be run inside the containers. These are not officially supported languages of the offering, but must be manually configured by the customer.

2. Apprenda is a `private` PaaS only. it can be deployed on public infrastructures but it is still one instance of the PaaS for each customer.

3. Infrastructures are removed as Apprenda can be deployed to 'any' infrastructure as a `private` PaaS.

4. I'm still not convinced with the selection of `addons` for Apprenda. This is the definition of add-ons:
> Add-on services are provided by external vendors and may or may not be hosted in the same infrastructure as the PaaS. However, we only categorize services as add-ons if they can be provisioned directly from the PaaS and will be billed as additional part of the platform fee, including capabilities like SSO.

A lot of add-ons you listed will probably not fall into this category?!