### PR TITLE
Fix CF Provider runtime etc. support warnings

### DIFF
--- a/profiles/anynines.json
+++ b/profiles/anynines.json
@@ -25,13 +25,7 @@
     {
       "language": "groovy",
       "versions": [
-        "1.5.*",
-        "1.6.*",
-        "1.7.*",
-        "1.8.*",
-        "2.0.*",
-        "2.1.*",
-        "2.2.*"
+        "*.*"
       ]
     },
     {
@@ -45,25 +39,49 @@
     {
       "language": "node",
       "versions": [
-        "0.4.*",
-        "0.6.*",
-        "0.8.*",
-        "0.10.*"
+        "0.10.*",
+        "0.12.*",
+        "4.*",
+        "5.*",
+        "6.*"
       ]
     },
     {
       "language": "ruby",
       "versions": [
-        "1.8.7",
-        "1.9.2",
-        "1.9.3",
-        "2.0.0"
+        "2.1.*",
+        "2.2.*",
+        "2.3.*"
+      ]
+    },
+    {
+      "language": "php",
+      "versions": [
+        "5.5.*",
+        "5.6.*",
+        "7.0.*"
+      ]
+    },
+    {
+      "language": "python",
+      "versions": [
+        "2.7.*",
+        "3.3.*",
+        "3.4.*",
+        "3.5.*"
       ]
     },
     {
       "language": "scala",
       "versions": [
-
+        "*.*"
+      ]
+    },
+    {
+      "language": "go",
+      "versions": [
+        "1.5.*",
+        "1.6.*"
       ]
     }
   ],
@@ -72,8 +90,8 @@
       "name": "tomcat",
       "runtime": "java",
       "versions": [
-        "6.0.*",
-        "7.0.*"
+        "6",
+        "7"
       ]
     }
   ],
@@ -86,14 +104,14 @@
       ]
     },
     {
-      "name": "lift",
-      "runtime": "scala",
+      "name": "play",
+      "runtime": "java",
       "versions": [
 
       ]
     },
     {
-      "name": "play",
+      "name": "spring",
       "runtime": "java",
       "versions": [
 
@@ -114,8 +132,15 @@
       ]
     },
     {
-      "name": "spring",
-      "runtime": "java",
+      "name": "cake",
+      "runtime": "php",
+      "versions": [
+
+      ]
+    },
+    {
+      "name": "symfony",
+      "runtime": "php",
       "versions": [
 
       ]

--- a/profiles/appfog.json
+++ b/profiles/appfog.json
@@ -22,72 +22,96 @@
   },
   "runtimes": [
     {
+      "language": "groovy",
+      "versions": [
+        "*.*"
+      ]
+    },
+    {
       "language": "java",
       "versions": [
-        "1.7.0"
+        "1.6.*",
+        "1.7.*",
+        "1.8.*"
       ]
     },
     {
       "language": "node",
       "versions": [
-        "0.4.12",
-        "0.6.17",
-        "0.8.14",
-        "0.10.29"
-      ]
-    },
-    {
-      "language": "php",
-      "versions": [
-        "5.3.10",
-        "5.4.33",
-        "5.5.17",
-        "5.6.1"
-      ]
-    },
-    {
-      "language": "python",
-      "versions": [
-        "2.7.3"
+        "0.10.*",
+        "0.12.*",
+        "4.*",
+        "5.*",
+        "6.*"
       ]
     },
     {
       "language": "ruby",
       "versions": [
-        "1.8.7",
-        "1.9.2",
-        "1.9.3"
+        "2.1.*",
+        "2.2.*",
+        "2.3.*"
+      ]
+    },
+    {
+      "language": "php",
+      "versions": [
+        "5.5.*",
+        "5.6.*",
+        "7.0.*"
+      ]
+    },
+    {
+      "language": "python",
+      "versions": [
+        "2.7.*",
+        "3.3.*",
+        "3.4.*",
+        "3.5.*"
+      ]
+    },
+    {
+      "language": "scala",
+      "versions": [
+        "*.*"
+      ]
+    },
+    {
+      "language": "go",
+      "versions": [
+        "1.5.*",
+        "1.6.*"
       ]
     }
   ],
   "middleware": [
     {
-      "name": "gunicorn",
-      "runtime": "python",
-      "versions": [
-
-      ]
-    },
-    {
       "name": "tomcat",
       "runtime": "java",
       "versions": [
-        "6"
+        "6",
+        "7"
       ]
     }
   ],
   "frameworks": [
     {
-      "name": "django",
-      "runtime": "python",
+      "name": "grails",
+      "runtime": "groovy",
       "versions": [
-        "1.3",
-        "1.4"
+
       ]
     },
     {
-      "name": "flask",
-      "runtime": "python",
+      "name": "play",
+      "runtime": "java",
+      "versions": [
+
+      ]
+    },
+    {
+      "name": "spring",
+      "runtime": "java",
       "versions": [
 
       ]
@@ -96,8 +120,28 @@
       "name": "rails",
       "runtime": "ruby",
       "versions": [
-        "3.0",
-        "3.1"
+
+      ]
+    },
+    {
+      "name": "sinatra",
+      "runtime": "ruby",
+      "versions": [
+
+      ]
+    },
+    {
+      "name": "cake",
+      "runtime": "php",
+      "versions": [
+
+      ]
+    },
+    {
+      "name": "symfony",
+      "runtime": "php",
+      "versions": [
+
       ]
     }
   ],

--- a/profiles/atos_cloud_foundry.json
+++ b/profiles/atos_cloud_foundry.json
@@ -30,69 +30,65 @@
   },
   "runtimes": [
     {
-      "language": "clojure",
-      "versions": [
-
-      ]
-    },
-    {
       "language": "groovy",
       "versions": [
-
-      ]
-    },
-    {
-      "language": "go",
-      "versions": [
-
+        "*.*"
       ]
     },
     {
       "language": "java",
       "versions": [
-
+        "1.6.*",
+        "1.7.*",
+        "1.8.*"
       ]
     },
     {
       "language": "node",
       "versions": [
-
-      ]
-    },
-    {
-      "language": "scala",
-      "versions": [
-
-      ]
-    },
-    {
-      "language": "php",
-      "versions": [
-
-      ]
-    },
-    {
-      "language": "python",
-      "versions": [
-
+        "0.10.*",
+        "0.12.*",
+        "4.*",
+        "5.*",
+        "6.*"
       ]
     },
     {
       "language": "ruby",
       "versions": [
-      
+        "2.1.*",
+        "2.2.*",
+        "2.3.*"
       ]
     },
     {
-      "language": "dotnet",
+      "language": "php",
       "versions": [
-
+        "5.5.*",
+        "5.6.*",
+        "7.0.*"
       ]
     },
     {
-      "language": "swift",
+      "language": "python",
       "versions": [
-
+        "2.7.*",
+        "3.3.*",
+        "3.4.*",
+        "3.5.*"
+      ]
+    },
+    {
+      "language": "scala",
+      "versions": [
+        "*.*"
+      ]
+    },
+    {
+      "language": "go",
+      "versions": [
+        "1.5.*",
+        "1.6.*"
       ]
     }
   ],
@@ -101,21 +97,8 @@
       "name": "tomcat",
       "runtime": "java",
       "versions": [
-
-      ]
-    },
-    {
-      "name": "tomee",
-      "runtime": "java",
-      "versions": [
-
-      ]
-    },
-    {
-      "name": "jboss",
-      "runtime": "java",
-      "versions": [
-
+        "6",
+        "7"
       ]
     }
   ],
@@ -124,7 +107,7 @@
       "name": "grails",
       "runtime": "groovy",
       "versions": [
-      
+
       ]
     },
     {
@@ -138,18 +121,11 @@
       "name": "spring",
       "runtime": "java",
       "versions": [
-      
+
       ]
     },
     {
       "name": "rails",
-      "runtime": "ruby",
-      "versions": [
-      
-      ]
-    },
-    {
-      "name": "rack",
       "runtime": "ruby",
       "versions": [
 
@@ -159,21 +135,21 @@
       "name": "sinatra",
       "runtime": "ruby",
       "versions": [
-      
+
       ]
     },
     {
-      "name": "hhvm",
+      "name": "cake",
       "runtime": "php",
       "versions": [
-    
+
       ]
     },
     {
-      "name": "django",
-      "runtime": "python",
+      "name": "symfony",
+      "runtime": "php",
       "versions": [
-    
+
       ]
     }
   ],

--- a/profiles/bluemix.json
+++ b/profiles/bluemix.json
@@ -22,46 +22,100 @@
   },
   "runtimes": [
     {
+      "language": "groovy",
+      "versions": [
+        "*.*"
+      ]
+    },
+    {
       "language": "java",
       "versions": [
-
+        "1.6.*",
+        "1.7.*",
+        "1.8.*"
       ]
     },
     {
       "language": "node",
       "versions": [
-
+        "0.10.*",
+        "0.12.*",
+        "4.*",
+        "5.*",
+        "6.*"
       ]
     },
     {
       "language": "ruby",
       "versions": [
-
-      ]
-    },
-    {
-      "language": "go",
-      "versions": [
-
+        "2.1.*",
+        "2.2.*",
+        "2.3.*"
       ]
     },
     {
       "language": "php",
       "versions": [
-
+        "5.5.*",
+        "5.6.*",
+        "7.0.*"
       ]
     },
     {
       "language": "python",
       "versions": [
-
+        "2.7.*",
+        "3.3.*",
+        "3.4.*",
+        "3.5.*"
+      ]
+    },
+    {
+      "language": "scala",
+      "versions": [
+        "*.*"
+      ]
+    },
+    {
+      "language": "go",
+      "versions": [
+        "1.5.*",
+        "1.6.*"
       ]
     }
   ],
   "middleware": [
-
+    {
+      "name": "tomcat",
+      "runtime": "java",
+      "versions": [
+        "6",
+        "7"
+      ]
+    }
   ],
   "frameworks": [
+    {
+      "name": "grails",
+      "runtime": "groovy",
+      "versions": [
+
+      ]
+    },
+    {
+      "name": "play",
+      "runtime": "java",
+      "versions": [
+
+      ]
+    },
+    {
+      "name": "spring",
+      "runtime": "java",
+      "versions": [
+
+      ]
+    },
     {
       "name": "rails",
       "runtime": "ruby",
@@ -72,6 +126,20 @@
     {
       "name": "sinatra",
       "runtime": "ruby",
+      "versions": [
+
+      ]
+    },
+    {
+      "name": "cake",
+      "runtime": "php",
+      "versions": [
+
+      ]
+    },
+    {
+      "name": "symfony",
+      "runtime": "php",
       "versions": [
 
       ]

--- a/profiles/devpack.json
+++ b/profiles/devpack.json
@@ -20,7 +20,7 @@
   },
   "runtimes": [
     {
-      "language": "go",
+      "language": "groovy",
       "versions": [
         "*.*"
       ]
@@ -28,6 +28,7 @@
     {
       "language": "java",
       "versions": [
+        "1.6.*",
         "1.7.*",
         "1.8.*"
       ]
@@ -35,39 +36,36 @@
     {
       "language": "node",
       "versions": [
-        "0.4.*",
-        "0.6.*",
-        "0.8.*",
         "0.10.*",
-        "0.12.*"
+        "0.12.*",
+        "4.*",
+        "5.*",
+        "6.*"
+      ]
+    },
+    {
+      "language": "ruby",
+      "versions": [
+        "2.1.*",
+        "2.2.*",
+        "2.3.*"
       ]
     },
     {
       "language": "php",
       "versions": [
-        "5.3",
-        "5.4",
-        "5.5",
-        "5.6"
+        "5.5.*",
+        "5.6.*",
+        "7.0.*"
       ]
     },
     {
       "language": "python",
       "versions": [
         "2.7.*",
-        "3.2.*",
         "3.3.*",
-        "3.4.*"
-      ]
-    },
-    {
-      "language": "ruby",
-      "versions": [
-        "1.8.*",
-        "1.9.*",
-        "2.0.*",
-        "2.1.*",
-        "2.2.*"
+        "3.4.*",
+        "3.5.*"
       ]
     },
     {
@@ -75,84 +73,73 @@
       "versions": [
         "*.*"
       ]
+    },
+    {
+      "language": "go",
+      "versions": [
+        "1.5.*",
+        "1.6.*"
+      ]
     }
   ],
-  "middleware": null,
+  "middleware": [
+    {
+      "name": "tomcat",
+      "runtime": "java",
+      "versions": [
+        "6",
+        "7"
+      ]
+    }
+  ],
   "frameworks": [
     {
-      "name": "rails",
-      "runtime": "ruby",
+      "name": "grails",
+      "runtime": "groovy",
       "versions": [
-        "2.*",
-        "3.*",
-        "4.*"
-      ]
-    },
-    {
-      "name": "django",
-      "runtime": "python",
-      "versions": [
-        "*.*"
-      ]
-    },
-    {
-      "name": "meteor",
-      "runtime": "node",
-      "versions": [
-        "0.9.*",
-        "1.0.*",
-        "1.1.*"
-      ]
-    },
-    {
-      "name": "express",
-      "runtime": "node",
-      "versions": [
-        "*.*"
-      ]
-    },
-    {
-      "name": "meanjs",
-      "runtime": "node",
-      "versions": [
-        "*.*"
+
       ]
     },
     {
       "name": "play",
       "runtime": "java",
       "versions": [
-        "1.2.*",
-        "2.*"
+
       ]
     },
     {
-      "name": "flask",
-      "runtime": "python",
-      "versions": [
-        "*.*"
-      ]
-    },
-    {
-      "name": "spark",
+      "name": "spring",
       "runtime": "java",
       "versions": [
-        "1.*",
-        "2.*"
+
+      ]
+    },
+    {
+      "name": "rails",
+      "runtime": "ruby",
+      "versions": [
+
+      ]
+    },
+    {
+      "name": "sinatra",
+      "runtime": "ruby",
+      "versions": [
+
+      ]
+    },
+    {
+      "name": "cake",
+      "runtime": "php",
+      "versions": [
+
       ]
     },
     {
       "name": "symfony",
       "runtime": "php",
       "versions": [
-        "2.*"
-      ]
-    },
-    {
-      "name": "cakephp",
-      "runtime": "php",
-      "versions": [
-        "2.*"
+
       ]
     }
   ],

--- a/profiles/hpe_helion_stackato.json
+++ b/profiles/hpe_helion_stackato.json
@@ -21,72 +21,55 @@
     "horizontal": true,
     "auto": true
   },
+
   "runtimes": [
-    {
-      "language": "clojure",
-      "versions": [
-        "1.2.1"
-      ]
-    },
-    {
-      "language": "go",
-      "versions": [
-        "1.2"
-      ]
-    },
     {
       "language": "groovy",
       "versions": [
-        "1.5.*",
-        "1.6.*",
-        "1.7.*",
-        "1.8.*",
-        "2.0.*",
-        "2.1.*"
+        "*.*"
       ]
     },
     {
       "language": "java",
       "versions": [
-        "1.7",
-        "1.6"
+        "1.6.*",
+        "1.7.*",
+        "1.8.*"
       ]
     },
     {
       "language": "node",
       "versions": [
-        "0.6.20",
-        "0.8.22",
-        "0.10.1",
-        "0.10.31"
-      ]
-    },
-    {
-      "language": "perl",
-      "versions": [
-        "5.16"
-      ]
-    },
-    {
-      "language": "php",
-      "versions": [
-        "5.3",
-        "5.5"
-      ]
-    },
-    {
-      "language": "python",
-      "versions": [
-        "2.7",
-        "3.3"
+        "0.10.*",
+        "0.12.*",
+        "4.*",
+        "5.*",
+        "6.*"
       ]
     },
     {
       "language": "ruby",
       "versions": [
-        "1.9.2",
-        "1.9.3",
-        "2.0.0"
+        "2.1.*",
+        "2.2.*",
+        "2.3.*"
+      ]
+    },
+    {
+      "language": "php",
+      "versions": [
+        "5.5.*",
+        "5.6.*",
+        "7.0.*"
+      ]
+    },
+    {
+      "language": "python",
+      "versions": [
+        "2.7.*",
+        "3.3.*",
+        "3.4.*",
+        "3.5.*"
       ]
     },
     {
@@ -94,35 +77,22 @@
       "versions": [
         "*.*"
       ]
+    },
+    {
+      "language": "go",
+      "versions": [
+        "1.5.*",
+        "1.6.*"
+      ]
     }
   ],
   "middleware": [
     {
-      "name": "apache",
-      "versions": [
-        "2.4.9"
-      ]
-    },
-    {
-      "name": "jboss",
-      "runtime": "java",
-      "versions": [
-        "7.0.2"
-      ]
-    },
-    {
-      "name": "nginx",
-      "versions": [
-        "1.6"
-      ]
-    },
-    {
       "name": "tomcat",
       "runtime": "java",
       "versions": [
-        "6.0.*",
-        "7.0.*",
-        "8.0.*"
+        "6",
+        "7"
       ]
     }
   ],
@@ -138,8 +108,14 @@
       "name": "play",
       "runtime": "java",
       "versions": [
-        "1.2.*",
-        "2.0.*"
+
+      ]
+    },
+    {
+      "name": "spring",
+      "runtime": "java",
+      "versions": [
+
       ]
     },
     {
@@ -157,8 +133,15 @@
       ]
     },
     {
-      "name": "spring",
-      "runtime": "java",
+      "name": "cake",
+      "runtime": "php",
+      "versions": [
+
+      ]
+    },
+    {
+      "name": "symfony",
+      "runtime": "php",
       "versions": [
 
       ]

--- a/profiles/pivotal_cf.json
+++ b/profiles/pivotal_cf.json
@@ -17,16 +17,12 @@
     "horizontal": true,
     "auto": true
   },
+
   "runtimes": [
     {
       "language": "groovy",
       "versions": [
-        "1.5.*",
-        "1.6.*",
-        "1.7.*",
-        "1.8.*",
-        "2.0.*",
-        "2.1.*"
+        "*.*"
       ]
     },
     {
@@ -40,44 +36,49 @@
     {
       "language": "node",
       "versions": [
-        "0.4.*",
-        "0.6.*",
-        "0.8.*",
-        "0.10.*"
+        "0.10.*",
+        "0.12.*",
+        "4.*",
+        "5.*",
+        "6.*"
       ]
     },
     {
       "language": "ruby",
       "versions": [
-        "1.8.7",
-        "1.9.2",
-        "1.9.3",
-        "2.0.0"
-      ]
-    },
-    {
-      "language": "scala",
-      "versions": [
-
-      ]
-    },
-    {
-      "language": "go",
-      "versions": [
-        "1.1",
-        "1.2"
-      ]
-    },
-    {
-      "language": "python",
-      "versions": [
-
+        "2.1.*",
+        "2.2.*",
+        "2.3.*"
       ]
     },
     {
       "language": "php",
       "versions": [
-
+        "5.5.*",
+        "5.6.*",
+        "7.0.*"
+      ]
+    },
+    {
+      "language": "python",
+      "versions": [
+        "2.7.*",
+        "3.3.*",
+        "3.4.*",
+        "3.5.*"
+      ]
+    },
+    {
+      "language": "scala",
+      "versions": [
+        "*.*"
+      ]
+    },
+    {
+      "language": "go",
+      "versions": [
+        "1.5.*",
+        "1.6.*"
       ]
     }
   ],
@@ -123,6 +124,20 @@
     {
       "name": "sinatra",
       "runtime": "ruby",
+      "versions": [
+
+      ]
+    },
+    {
+      "name": "cake",
+      "runtime": "php",
+      "versions": [
+
+      ]
+    },
+    {
+      "name": "symfony",
+      "runtime": "php",
       "versions": [
 
       ]

--- a/profiles/pivotal_web_services.json
+++ b/profiles/pivotal_web_services.json
@@ -24,12 +24,7 @@
     {
       "language": "groovy",
       "versions": [
-        "1.5.*",
-        "1.6.*",
-        "1.7.*",
-        "1.8.*",
-        "2.0.*",
-        "2.1.*"
+        "*.*"
       ]
     },
     {
@@ -43,32 +38,49 @@
     {
       "language": "node",
       "versions": [
-        "0.4.*",
-        "0.6.*",
-        "0.8.*",
-        "0.10.*"
+        "0.10.*",
+        "0.12.*",
+        "4.*",
+        "5.*",
+        "6.*"
       ]
     },
     {
       "language": "ruby",
       "versions": [
-        "1.8.7",
-        "1.9.2",
-        "1.9.3",
-        "2.0.0"
+        "2.1.*",
+        "2.2.*",
+        "2.3.*"
+      ]
+    },
+    {
+      "language": "php",
+      "versions": [
+        "5.5.*",
+        "5.6.*",
+        "7.0.*"
+      ]
+    },
+    {
+      "language": "python",
+      "versions": [
+        "2.7.*",
+        "3.3.*",
+        "3.4.*",
+        "3.5.*"
       ]
     },
     {
       "language": "scala",
       "versions": [
-
+        "*.*"
       ]
     },
     {
       "language": "go",
       "versions": [
-        "1.1",
-        "1.2"
+        "1.5.*",
+        "1.6.*"
       ]
     }
   ],
@@ -114,6 +126,20 @@
     {
       "name": "sinatra",
       "runtime": "ruby",
+      "versions": [
+
+      ]
+    },
+    {
+      "name": "cake",
+      "runtime": "php",
+      "versions": [
+
+      ]
+    },
+    {
+      "name": "symfony",
+      "runtime": "php",
       "versions": [
 
       ]


### PR DESCRIPTION
copy runtimes, middleware and framework sections from cloud foundry to all cf providers. need to find a way to automate this but at least it fixes all warnings for now
