### PR TITLE
Consider not locking minor Ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.4.2'
+ruby '~> 2'
 
 gem 'activesupport'
 gem 'geocoder'


### PR DESCRIPTION
It makes it harder to  run tests locally when you lock to an old minor version of Ruby ... and I don't think there is a good reason for doing so?